### PR TITLE
wrong URL in content

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 setuptools.setup(
     name='Flask-CDN',
     version='1.5.1',
-    url='https://libwilliam.github.io/flask-compress/',
+    url='https://libwilliam.github.io/flask-cdn/',
     license='MIT',
     author='William Fagan',
     author_email='libwilliam@gmail.com',


### PR DESCRIPTION
current version has content in url= parameter which points to another package (flask-compress) and also makes it wrong on PyPI. This change updates back to proper (and tested) one.