### PR TITLE
Added an option to append a specific version string to the generated URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Within your Flask application’s settings you can provide the following setting
 | `CDN_DOMAIN` | Set the base domain for your CDN here. | `None` |
 | `CDN_HTTPS` | Specifies whether or not to serve your assets over HTTPS. If not specified the asset will be served by the same method the request comes in as. | `None` |
 | `CDN_TIMESTAMP` | Specifies whether or not to add a timestamp to the generated urls. | `True` |
+| `CDN_VERSION` | The version string to add to the generated urls. Useful when the timestamps of your files are different across servers or if you just want a more stable cache key. | `None` |
 | `CDN_ENDPOINTS` | The list of endpoints that will be rewritten to use the CDN. Endpoints will be checked for an exact match and also if it ends with a period followed by the endpoint name. | `['static']` |
 
 

--- a/flask_cdn.py
+++ b/flask_cdn.py
@@ -53,6 +53,8 @@ def url_for(endpoint, **values):
             path = os.path.join(static_folder, values['filename'])
             values['t'] = int(os.path.getmtime(path))
 
+        values['v'] = app.config['CDN_VERSION']
+
         return urls.build(endpoint, values=values, force_external=True)
 
     return flask_url_for(endpoint, **values)
@@ -86,6 +88,7 @@ class CDN(object):
                     ('CDN_DOMAIN', None),
                     ('CDN_HTTPS', None),
                     ('CDN_TIMESTAMP', True),
+                    ('CDN_VERSION', None),
                     ('CDN_ENDPOINTS', ['static'])]
 
         for k, v in defaults:

--- a/index.html
+++ b/index.html
@@ -133,6 +133,11 @@ cdn <span class="pl-k">=</span> CDN()
 <td><code>True</code></td>
 </tr>
 <tr>
+<td><code>CDN_VERSION</code></td>
+<td>The version string to add to the generated urls. Usefull when the timestamps of your files are different across servers or if you just want a more stable cache key.</td>
+<td><code>None</code></td>
+</tr>
+<tr>
 <td><code>CDN_ENDPOINTS</code></td>
 <td>The list of endpoints that will be rewritten to use the CDN. Endpoints will be checked for an exact match and also if it ends with a period followed by the endpoint name.</td>
 <td><code>['static']</code></td>

--- a/tests/test_flask_cdn.py
+++ b/tests/test_flask_cdn.py
@@ -144,6 +144,7 @@ class UrlTests(unittest.TestCase):
         self.assertEquals(self.client_get(ufs, secure=True).get_data(True),
                           exp)
 
+
 class BlueprintTest(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)

--- a/tests/test_flask_cdn.py
+++ b/tests/test_flask_cdn.py
@@ -110,6 +110,20 @@ class UrlTests(unittest.TestCase):
         exp = 'http://mycdnname.cloudfront.net/static/bah.js'
         self.assertEquals(self.client_get(ufs).get_data(True), exp)
 
+    def test_url_for_version(self):
+        """ Tests that CDN_VERSION correctly affects the generated URLs. """
+        ufs = "{{ url_for('static', filename='bah.js') }}"
+
+        VERSION = '1.1-2'
+        self.app.config['CDN_VERSION'] = VERSION
+        path = os.path.join(self.app.static_folder, 'bah.js')
+        exp = 'http://mycdnname.cloudfront.net/static/bah.js?v={0}'.format(VERSION)
+        self.assertEquals(self.client_get(ufs).get_data(True), exp)
+
+        self.app.config['CDN_VERSION'] = None
+        exp = 'http://mycdnname.cloudfront.net/static/bah.js'
+        self.assertEquals(self.client_get(ufs).get_data(True), exp)
+
     def test_for_scheme(self):
         """ Tests _scheme correctly overrides CDN_HTTPS option. """
         ufs = "{{ url_for('static', filename='bah.js', _scheme='https') }}"
@@ -129,7 +143,6 @@ class UrlTests(unittest.TestCase):
         exp = '//mycdnname.cloudfront.net/static/bah.js'
         self.assertEquals(self.client_get(ufs, secure=True).get_data(True),
                           exp)
-
 
 class BlueprintTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Added an option to specify a version string to add to the generated urls. This can be useful when the timestamps of the static files are different across servers or if there is a wish to have a more stable cache busting key.